### PR TITLE
Add inside,outside to operator precedence list

### DIFF
--- a/book/src/05_language_reference/04_expression/01_operator_precedence.md
+++ b/book/src/05_language_reference/04_expression/01_operator_precedence.md
@@ -18,4 +18,4 @@ In expression, operator precedence is almost the same as SystemVerilog.
 |`&&`                                                                                  |Left         |          |
 |<code>\|\|</code>                                                                     |Left         |          |
 |`=` `+=` `-=` `*=` `/=` `%=` `&=` `^=` <code>\|=</code> <br> `<<=` `>>=` `<<<=` `>>>=`|None         |          |
-|`{}` `inside` `outside`                                                               |None         |Lowest    |
+|`{}` `inside` `outside` `if` `case` `switch`                                          |None         |Lowest    |

--- a/book/src/05_language_reference/04_expression/01_operator_precedence.md
+++ b/book/src/05_language_reference/04_expression/01_operator_precedence.md
@@ -18,4 +18,4 @@ In expression, operator precedence is almost the same as SystemVerilog.
 |`&&`                                                                                  |Left         |          |
 |<code>\|\|</code>                                                                     |Left         |          |
 |`=` `+=` `-=` `*=` `/=` `%=` `&=` `^=` <code>\|=</code> <br> `<<=` `>>=` `<<<=` `>>>=`|None         |          |
-|`{}`                                                                                  |None         |Lowest    |
+|`{}` `inside` `outside`                                                               |None         |Lowest    |


### PR DESCRIPTION
SystemVerilogのLRMと見比べていたらinside, outsideがないことに気付いたので追加しました。
repeatも追加しようかと思ったのですが、repeat単体では使えないので追加していません。