### PR TITLE
Fix number of argument of `$clog2` system function

### DIFF
--- a/book/src/05_language_reference/04_expression/02_function_call.md
+++ b/book/src/05_language_reference/04_expression/02_function_call.md
@@ -13,6 +13,6 @@ package PackageA {
 
 module ModuleA {
     let _a: logic = PackageA::FunctionA(1, 1);
-    let _b: logic = $clog2(1, 1);
+    let _b: logic = $clog2(1);
 }
 ```


### PR DESCRIPTION
The `$clog2` system function can take one argument only but the example does not.
This PR is fix it.