### PR TITLE
Update documentation for `waveform_format` option

### DIFF
--- a/book/po/ja.po
+++ b/book/po/ja.po
@@ -5993,12 +5993,12 @@ msgstr "`waveform_target` フィールドは波形の生成先を指定します
 #: src/06_development_environment/01_project_configuration/04_test.md:64
 msgid ""
 "```toml\n"
-"[build]\n"
+"[test]\n"
 "waveform_target = {type = \"directory\", path = \"[dst dir]\"}\n"
 "```"
 msgstr ""
 "```toml\n"
-"[build]\n"
+"[test]\n"
 "waveform_target = {type = \"directory\", path = \"[dst dir]\"}\n"
 "```"
 

--- a/book/src/06_development_environment/01_project_configuration/04_test.md
+++ b/book/src/06_development_environment/01_project_configuration/04_test.md
@@ -65,3 +65,11 @@ If you want to use `directory`, you should specify the target path by `path` key
 [test]
 waveform_target = {type = "directory", path = "[dst dir]"}
 ```
+
+## The `waveform_format` field
+
+The `waveform_format` field specifies in which format the waveform will be dumped.
+The available formats are:
+
+* `vcd` -- The default value and most readable format across all vendors. But also not very feature rich
+* `fst` -- This format has some more features, e.g. printing enum values instead of integers. `gtkwave` and `surfer` can read this format.

--- a/book/src/06_development_environment/01_project_configuration/04_test.md
+++ b/book/src/06_development_environment/01_project_configuration/04_test.md
@@ -62,6 +62,6 @@ The available types are below:
 If you want to use `directory`, you should specify the target path by `path` key.
 
 ```toml
-[build]
+[test]
 waveform_target = {type = "directory", path = "[dst dir]"}
 ```


### PR DESCRIPTION
This can be merged as soon as https://github.com/veryl-lang/veryl/pull/1388 is accepted.

What's maybe missing is the japanese translation for the new text. Feel free to add it.