### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["dalance"]
 language = "en"
-multilingual = false
 src = "src"
 title = "The Veryl Hardware Description Language"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10