### PR TITLE
Execute deploy task every night

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - main
     tags:
       - 'v*.*.*'
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
 
 env:
   # Update the language picker in index.hbs to link new languages.


### PR DESCRIPTION
Currently, nightly doc and playground are deployed when this repository is updated so playground does not follow the latest veryl codebase.
To fix this problem, the deploy task should be executed every night automatically.