### PR TITLE
Fix cron configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - 'v*.*.*'
   schedule:
-    - cron: 0 0 * * *
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Cron configuration includes `*` characters so it must be quated.
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onschedule