### PR TITLE
Add comment related to `struct`/`enum`/`union` declarations

### DIFF
--- a/book/mkdocs.yml
+++ b/book/mkdocs.yml
@@ -1,0 +1,2 @@
+markdown_extensions:
+  - admonition

--- a/book/src/05_language_reference/03_data_type/02_user_defined_type.md
+++ b/book/src/05_language_reference/03_data_type/02_user_defined_type.md
@@ -21,6 +21,9 @@ module ModuleA {
 }
 ```
 
+!!! Note
+    You can define `struct` data types within module and package declarations but not interface declaration.
+
 ## Enum
 
 `enum` is enumerable type.
@@ -55,6 +58,9 @@ module A {
     }
 }
 ```
+
+!!! Note
+    You can define `enum` data types within module and package declarations but not interface declarations.
 
 ### Enum Encoding
 
@@ -102,6 +108,9 @@ module A {
     assign a.variant_a = 8'haa;
 }
 ```
+
+!!! Note
+    You can define `union` data types within module and package declarations but not interface declarations.
 
 ## Typedef
 

--- a/book/src/07_appendix/02_semantic_error.md
+++ b/book/src/07_appendix/02_semantic_error.md
@@ -18,6 +18,10 @@
 
 ## invalid_system_function
 
+## invalid_type_declaration
+
+This error is reported when `struct`, `enum` and `union` data types are defined within interface declarations.
+
 ## mismatch_arity
 
 ## mismatch_attribute_args


### PR DESCRIPTION
Add comment that `struct`/`enum`/`union` data types cannot be declared within interface declarations.